### PR TITLE
Fix URL in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
         required: true
       - label: This issue only contains 1 issue (if you have multiple issues, open one issue for each issue).
         required: true
-      - label: This issue is not a duplicate issue of currently [previous issues](https://github.com/ludeeus/hass_nuki_bt/issues?q=is%3Aissue+label%3A%22Bug%22+)..
+      - label: This issue is not a duplicate issue of currently [previous issues](https://github.com/ronengr/hass_nuki_bt/issues?q=is%3Aissue+label%3A%22Bug%22+)..
         required: true
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
         required: true
       - label: This only contains 1 feature request (if you have multiple feature requests, open one feature request for each feature request).
         required: true
-      - label: This issue is not a duplicate feature request of [previous feature requests](https://github.com/ludeeus/hass_nuki_bt/issues?q=is%3Aissue+label%3A%22Feature+Request%22+).
+      - label: This issue is not a duplicate feature request of [previous feature requests](https://github.com/ronengr/hass_nuki_bt/issues?q=is%3Aissue+label%3A%22Feature+Request%22+).
         required: true
 
 - type: textarea


### PR DESCRIPTION
The URLs in the issue templates had the github templates' creator's name (ludeeus) instead of yours in the url and thus were pointing to an 404 page.