### PR TITLE
fix async_get_last_action_log_entry in coordinator.py

### DIFF
--- a/custom_components/hass_nuki_bt/coordinator.py
+++ b/custom_components/hass_nuki_bt/coordinator.py
@@ -141,6 +141,7 @@ class NukiDataUpdateCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
         return False
 
     async def async_get_last_action_log_entry(self):
+        """Get the last action log entry."""
         if self._security_pin:
             # get the latest log entry
             # todo: check if Nuki logging is enabled

--- a/custom_components/hass_nuki_bt/coordinator.py
+++ b/custom_components/hass_nuki_bt/coordinator.py
@@ -113,7 +113,7 @@ class NukiDataUpdateCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
         if service_info:
             self.device.set_ble_device(service_info.device)
         await self.device.update_state()
-        await self._async_get_last_action_log_entry()
+        await self.async_get_last_action_log_entry()
         self.async_update_nuki_listeners()
 
     @callback
@@ -140,7 +140,7 @@ class NukiDataUpdateCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
                 return True
         return False
 
-    async def _async_get_last_action_log_entry(self):
+    async def async_get_last_action_log_entry(self):
         if self._security_pin:
             # get the latest log entry
             # todo: check if Nuki logging is enabled


### PR DESCRIPTION
The method async_get_last_action_log_entry is called from [entity file](https://github.com/danielcaceresm/hass_nuki_bt/blob/7cc3831b13658bc5921aec2de274f61d2e5a65be/custom_components/hass_nuki_bt/entity.py#L67) and it fails due the method in coordinator has a leading underscore (as non-public member). I changed the method name to fix the issue.