### PR TITLE
pair: Support Nuki Gen 5 locks

### DIFF
--- a/custom_components/hass_nuki_bt/config_flow.py
+++ b/custom_components/hass_nuki_bt/config_flow.py
@@ -157,7 +157,7 @@ class NukiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         await device.connect()
         try:
-            ret = await device.pair()
+            ret = await device.pair(self._data[CONF_PIN])
         except NukiErrorException as ex:
             LOGGER.error(ex)
             if ex.error_code == NukiConst.ErrorCode.P_ERROR_NOT_PAIRING:

--- a/custom_components/hass_nuki_bt/manifest.json
+++ b/custom_components/hass_nuki_bt/manifest.json
@@ -20,7 +20,7 @@
     "pyNukiBT"
   ],
   "requirements": [
-    "pyNukiBT==0.0.18"
+    "pyNukiBT==0.0.19"
   ],
   "version": "0.0.0"
 }


### PR DESCRIPTION
The Nuki Gen 5 locks introduced API v2.3.0 which make the security pin on pairing mandatory. The pairing flow itself has changed a little bit, but this is handled in PyNukiBT.

closes #97 